### PR TITLE
Add setup helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ The server provides essential web crawling and search tools:
    git clone https://github.com/coleam00/mcp-crawl4ai-rag.git
    cd mcp-crawl4ai-rag
    ```
+To automate steps 2-4, run:
+```bash
+./setup.sh
+```
+
 
 2. Install uv if you don't have it:
    ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Simple helper script to set up a local development environment
+# Installs uv, creates a virtual environment, installs dependencies,
+# and runs crawl4ai-setup.
+set -euo pipefail
+
+pip install uv
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+crawl4ai-setup
+
+echo "Setup complete. Activate the environment with 'source .venv/bin/activate'"


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper script that installs `uv`, creates a venv, installs dependencies and runs `crawl4ai-setup`
- document the script near the manual setup instructions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68526edce6f883339e6f3989c98d19b2