### PR TITLE
Add configurable LLM request throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ OPENAI_API_KEY=your_openai_api_key
 # LLM for summaries and contextual embeddings
 MODEL_CHOICE=gpt-4.1-nano
 
+# LLM API Rate Limit Settings
+LLM_MAX_CONCURRENCY=3
+LLM_REQUEST_DELAY=0
+
 # RAG Strategies (set to "true" or "false", default to "false")
 USE_CONTEXTUAL_EMBEDDINGS=false
 USE_HYBRID_SEARCH=false
@@ -243,6 +247,12 @@ Enables AI hallucination detection and repository analysis using Neo4j knowledge
 - **Trade-offs**: Requires Neo4j setup and additional dependencies. Repository parsing can be slow for large codebases, and validation requires repositories to be pre-indexed.
 - **Cost**: No additional API costs for validation, but requires Neo4j infrastructure (can use free local installation or cloud AuraDB).
 - **Benefits**: Provides three powerful tools: `parse_github_repository` for indexing codebases, `check_ai_script_hallucinations` for validating AI-generated code, and `query_knowledge_graph` for exploring indexed repositories.
+
+### OpenAI Rate Limit Tuning
+Control LLM API load with two variables:
+- `LLM_MAX_CONCURRENCY` sets the number of parallel OpenAI requests.
+- `LLM_REQUEST_DELAY` waits (in seconds) after each request.
+For free or low-tier plans, try values like `LLM_MAX_CONCURRENCY=2` and `LLM_REQUEST_DELAY=0.5`.
 
 ### Recommended Configurations
 

--- a/src/crawl4ai_mcp.py
+++ b/src/crawl4ai_mcp.py
@@ -39,7 +39,8 @@ from utils import (
     add_code_examples_to_supabase,
     update_source_info,
     extract_source_summary,
-    search_code_examples
+    search_code_examples,
+    LLM_MAX_CONCURRENCY
 )
 
 # Import knowledge graph modules
@@ -464,7 +465,7 @@ async def crawl_single_page(ctx: Context, url: str) -> str:
                     code_metadatas = []
                     
                     # Process code examples in parallel
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=LLM_MAX_CONCURRENCY) as executor:
                         # Prepare arguments for parallel processing
                         summary_args = [(block['code'], block['context_before'], block['context_after']) 
                                         for block in code_blocks]
@@ -634,7 +635,7 @@ async def smart_crawl_url(ctx: Context, url: str, max_depth: int = 3, max_concur
             url_to_full_document[doc['url']] = doc['markdown']
         
         # Update source information for each unique source FIRST (before inserting documents)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=LLM_MAX_CONCURRENCY) as executor:
             source_summary_args = [(source_id, content) for source_id, content in source_content_map.items()]
             source_summaries = list(executor.map(lambda args: extract_source_summary(args[0], args[1]), source_summary_args))
         
@@ -664,7 +665,7 @@ async def smart_crawl_url(ctx: Context, url: str, max_depth: int = 3, max_concur
                 
                 if code_blocks:
                     # Process code examples in parallel
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=LLM_MAX_CONCURRENCY) as executor:
                         # Prepare arguments for parallel processing
                         summary_args = [(block['code'], block['context_before'], block['context_after']) 
                                         for block in code_blocks]


### PR DESCRIPTION
## Summary
- limit OpenAI request concurrency via `LLM_MAX_CONCURRENCY`
- add optional `LLM_REQUEST_DELAY` between requests
- apply limits to contextual embeddings and code example summarization
- document new env vars in README

## Testing
- `python -m py_compile src/utils.py src/crawl4ai_mcp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527377b07483338e430062b8d64141