### PR TITLE
Add markdown file indexing tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,8 @@ PORT=
 OPENAI_API_KEY=
 
 # The LLM you want to use for summaries and contextual embeddings
-# Generally this is a very cheap and fast LLM like gpt-4.1-nano
+# Generally this is a very cheap and fast LLM like gpt-4o-mini
+# This is used for the new index_markdown_file tool and contextual embeddings
 MODEL_CHOICE=
 
 # RAG strategies - set these to "true" or "false" (default to "false")

--- a/MARKDOWN_INDEXING_EXAMPLE.md
+++ b/MARKDOWN_INDEXING_EXAMPLE.md
@@ -1,0 +1,35 @@
+# Example: Indexing Markdown Files with Crawl4AI RAG MCP Server
+
+Modern documentation sites often use heavy JavaScript that prevents simple web crawling. A convenient workaround is to copy the rendered page as Markdown from your browser and save it locally. The new `index_markdown_file` tool lets you index these files directly so they can be used for retrieval augmented generation (RAG).
+
+## Use Case: OpenAI Documentation
+1. Visit [OpenAI's platform docs](https://platform.openai.com/docs).
+2. Use your browser's "Copy page as Markdown" option and save the result to `openai_docs.md`.
+3. Run the MCP tool to index the file:
+
+```json
+{
+  "tool": "index_markdown_file",
+  "file_path": "openai_docs.md"
+}
+```
+
+The server will chunk the file, store it in Supabase with contextual embeddings and (if enabled) extract code examples.
+
+## Workflow Steps
+1. Save documentation pages as `.md` or `.txt` files.
+2. Call `index_markdown_file` for each file. Optionally provide a custom `source_name`.
+3. Use `get_available_sources` to see the new source.
+4. Query the indexed content with `perform_rag_query` or search code snippets with `search_code_examples`.
+
+## Configuration Tips
+- Set `MODEL_CHOICE` in your `.env` file to a lightweight model like `gpt-4o-mini` for summaries and contextual embeddings.
+- Enable `USE_CONTEXTUAL_EMBEDDINGS=true` for better retrieval quality.
+- Enable `USE_AGENTIC_RAG=true` to store and search code examples from the markdown.
+
+## Benefits Over Web Crawling
+- Works offline and avoids issues with JavaScript-heavy sites.
+- Lets you curate exactly what content is indexed.
+- Fast indexing since no network requests are needed.
+
+Indexing markdown files expands Crawl4AI RAG MCP's flexibility, letting you bring your own documentation or notes into your RAG workflow.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <h1 align="center">Crawl4AI RAG MCP Server</h1>
 
 <p align="center">
-  <em>Web Crawling and RAG Capabilities for AI Agents and AI Coding Assistants</em>
+  <em>Markdown File Indexing, Web Crawling and RAG Capabilities for AI Agents and AI Coding Assistants</em>
 </p>
 
-A powerful implementation of the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) integrated with [Crawl4AI](https://crawl4ai.com) and [Supabase](https://supabase.com/) for providing AI agents and AI coding assistants with advanced web crawling and RAG capabilities.
+A powerful implementation of the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) integrated with [Crawl4AI](https://crawl4ai.com) and [Supabase](https://supabase.com/) for providing AI agents and AI coding assistants with advanced markdown file indexing, web crawling and RAG capabilities.
 
-With this MCP server, you can <b>scrape anything</b> and then <b>use that knowledge anywhere</b> for RAG.
+With this MCP server, you can <b>index markdown files and scrape anything</b> and then <b>use that knowledge anywhere</b> for RAG.
 
 The primary goal is to bring this MCP server into [Archon](https://github.com/coleam00/Archon) as I evolve it to be more of a knowledge engine for AI coding assistants to build AI agents. This first version of the Crawl4AI/RAG MCP server will be improved upon greatly soon, especially making it more configurable so you can use different embedding models and run everything locally with Ollama.
 
@@ -14,7 +14,7 @@ Consider this GitHub repository a testbed, hence why I haven't been super active
 
 ## Overview
 
-This MCP server provides tools that enable AI agents to crawl websites, store content in a vector database (Supabase), and perform RAG over the crawled content. It follows the best practices for building MCP servers based on the [Mem0 MCP server template](https://github.com/coleam00/mcp-mem0/) I provided on my channel previously.
+This MCP server provides tools that enable AI agents to index local markdown/text files, crawl websites, store content in a vector database (Supabase), and perform RAG over the content. It follows the best practices for building MCP servers based on the [Mem0 MCP server template](https://github.com/coleam00/mcp-mem0/) I provided on my channel previously.
 
 The server includes several advanced RAG strategies that can be enabled to enhance retrieval quality:
 - **Contextual Embeddings** for enriched semantic understanding
@@ -41,6 +41,7 @@ The Crawl4AI RAG MCP server is just the beginning. Here's where we're headed:
 
 ## Features
 
+- **Markdown File Indexing**: Index local markdown and text files with intelligent chunking and contextual embeddings
 - **Smart URL Detection**: Automatically detects and handles different URL types (regular webpages, sitemaps, text files)
 - **Recursive Crawling**: Follows internal links to discover content
 - **Parallel Processing**: Efficiently crawls multiple pages simultaneously
@@ -54,20 +55,21 @@ The server provides essential web crawling and search tools:
 
 ### Core Tools (Always Available)
 
-1. **`crawl_single_page`**: Quickly crawl a single web page and store its content in the vector database
-2. **`smart_crawl_url`**: Intelligently crawl a full website based on the type of URL provided (sitemap, llms-full.txt, or a regular webpage that needs to be crawled recursively)
-3. **`get_available_sources`**: Get a list of all available sources (domains) in the database
-4. **`perform_rag_query`**: Search for relevant content using semantic search with optional source filtering
+1. **`index_markdown_file`**: Index and chunk a local markdown or text file, storing it with contextual embeddings in Supabase
+2. **`crawl_single_page`**: Quickly crawl a single web page and store its content in the vector database
+3. **`smart_crawl_url`**: Intelligently crawl a full website based on the type of URL provided (sitemap, llms-full.txt, or a regular webpage that needs to be crawled recursively)
+4. **`get_available_sources`**: Get a list of all available sources (domains) in the database
+5. **`perform_rag_query`**: Search for relevant content using semantic search with optional source filtering
 
 ### Conditional Tools
 
-5. **`search_code_examples`** (requires `USE_AGENTIC_RAG=true`): Search specifically for code examples and their summaries from crawled documentation. This tool provides targeted code snippet retrieval for AI coding assistants.
+6. **`search_code_examples`** (requires `USE_AGENTIC_RAG=true`): Search specifically for code examples and their summaries from crawled documentation. This tool provides targeted code snippet retrieval for AI coding assistants.
 
 ### Knowledge Graph Tools (requires `USE_KNOWLEDGE_GRAPH=true`, see below)
 
-6. **`parse_github_repository`**: Parse a GitHub repository into a Neo4j knowledge graph, extracting classes, methods, functions, and their relationships for hallucination detection
-7. **`check_ai_script_hallucinations`**: Analyze Python scripts for AI hallucinations by validating imports, method calls, and class usage against the knowledge graph
-8. **`query_knowledge_graph`**: Explore and query the Neo4j knowledge graph with commands like `repos`, `classes`, `methods`, and custom Cypher queries
+7. **`parse_github_repository`**: Parse a GitHub repository into a Neo4j knowledge graph, extracting classes, methods, functions, and their relationships for hallucination detection
+8. **`check_ai_script_hallucinations`**: Analyze Python scripts for AI hallucinations by validating imports, method calls, and class usage against the knowledge graph
+9. **`query_knowledge_graph`**: Explore and query the Neo4j knowledge graph with commands like `repos`, `classes`, `methods`, and custom Cypher queries
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- add `index_markdown_file` tool for local markdown/text files
- update server description for markdown indexing
- document new feature and usage
- update env example for model choice comment

## Testing
- `python -m py_compile src/crawl4ai_mcp.py src/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685c31969d84833397995e6c76864a2c