### PR TITLE
Improve star import handling in analyzer

### DIFF
--- a/tests/test_ai_script_analyzer.py
+++ b/tests/test_ai_script_analyzer.py
@@ -33,3 +33,20 @@ def test_bare_datetime_instantiation(tmp_path):
     result = analyzer.analyze_script(str(path))
     assert any(ci.class_name == 'datetime' for ci in result.class_instantiations)
     assert not result.function_calls
+
+
+def test_star_import_resolution(tmp_path):
+    script = textwrap.dedent(
+        '''
+        from skidl import *
+        n = Net('test')
+        p = Part('Device', 'R')
+        '''
+    )
+    path = tmp_path / 'script.py'
+    path.write_text(script)
+    analyzer = AIScriptAnalyzer()
+    result = analyzer.analyze_script(str(path))
+    full_names = {ci.full_class_name for ci in result.class_instantiations}
+    assert 'skidl.Net' in full_names
+    assert 'skidl.Part' in full_names


### PR DESCRIPTION
## Summary
- track modules imported with `from X import *`
- resolve names from star imports when inferring full module paths
- test resolution of `Net` and `Part` from `skidl`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686916b13c84833384fc2c94d22c6edb