### PR TITLE
Update MCP modular package docs and entrypoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN uv pip install --system -e . && \
 EXPOSE ${PORT}
 
 # Command to run the MCP server
-CMD ["python", "src/crawl4ai_mcp.py"]
+CMD ["python", "-m", "crawl4ai_mcp.server"]

--- a/README.md
+++ b/README.md
@@ -143,11 +143,7 @@ Before running the server, you need to set up the database with the pgvector ext
 
 To enable AI hallucination detection and repository analysis features, you need to set up Neo4j.
 
-Prior versions required passing a file path to the hallucination checker, which
-made Docker usage awkward. A new `/api/check_script_hallucinations` endpoint now
-accepts raw script content so you can run the server in Docker without mounting
-files. If you do use file paths, they must point to files that exist inside the
-container—mount the necessary directories with Docker's `-v` flag.
+Scripts can be analyzed locally using the `knowledge_graphs/ai_hallucination_detector.py` utility.
 
 For installing Neo4j:
 
@@ -292,40 +288,6 @@ Once `USE_KNOWLEDGE_GRAPH=true` is set and Neo4j is running, you can:
    python knowledge_graphs/ai_hallucination_detector.py /path/to/your_script.py
    ```
 
-   Or send the script content directly:
-
-   **Using curl (macOS/Linux):**
-   ```bash
-   curl -X POST http://localhost:8051/api/check_script_hallucinations \
-        -H "Content-Type: application/json" \
-        -d '{"script_content": "print(123)", "filename": "example.py"}'
-   ```
-
-   **Using PowerShell (Windows):**
-   ```powershell
-   $headers = @{ "Content-Type" = "application/json" }
-   $script = [string](Get-Content .\your_script.py -Raw)
-   $bodyObj = @{
-       script_content = $script
-       filename = "your_script.py"
-   }
-   $body = $bodyObj | ConvertTo-Json -Compress
-   Invoke-RestMethod -Uri "http://localhost:8051/api/check_script_hallucinations" -Method Post -Headers $headers -Body $body
-   ```
-
-   **Using Python (cross-platform):**
-   ```python
-   import requests
-   
-  with open('your_script.py', 'r') as f:
-      script_content = f.read()
-   
-   response = requests.post(
-       'http://localhost:8051/api/check_script_hallucinations',
-       json={'script_content': script_content, 'filename': 'your_script.py'}
-   )
-   print(response.json())
-  ```
 
 
 ### Recommended Configurations
@@ -384,7 +346,7 @@ docker run --env-file .env -p 8051:8051 \
 ### Using Python
 
 ```bash
-uv run src/crawl4ai_mcp.py
+python -m crawl4ai_mcp.server
 ```
 
 The server will start and listen on the configured host and port.
@@ -434,7 +396,7 @@ Add this server to your MCP configuration for Claude Desktop, Windsurf, or any o
   "mcpServers": {
     "crawl4ai-rag": {
       "command": "python",
-      "args": ["path/to/crawl4ai-mcp/src/crawl4ai_mcp.py"],
+      "args": ["-m", "crawl4ai_mcp.server"],
       "env": {
         "TRANSPORT": "stdio",
         "OPENAI_API_KEY": "your_openai_api_key",

--- a/docs/query_knowledge_graph_tool_documentation.md
+++ b/docs/query_knowledge_graph_tool_documentation.md
@@ -34,7 +34,7 @@ async def query_knowledge_graph(ctx: Context, command: str) -> str
 - **Returns**: JSON `str` describing the result or error.
 - **Errors**: Returns a JSON object with `success: false` and an `error` message if the command fails or if the knowledge graph is disabled.
 
-The function automatically checks that `USE_KNOWLEDGE_GRAPH=true` and that a Neo4j driver is available before executing any query【F:src/crawl4ai_mcp.py†L1308-L1370】.
+The function automatically checks that `USE_KNOWLEDGE_GRAPH=true` and that a Neo4j driver is available before executing any query.
 
 ## Available Commands
 
@@ -109,17 +109,17 @@ When an error occurs `success` is `false` and an `error` field is present.
 }
 ```
 
-See `src/crawl4ai_mcp.py` for exact return fields of each handler.
+See `crawl4ai_mcp/tools.py` for exact return fields of each handler.
 
 ## Error Handling
 
 Possible errors include:
-- Knowledge graph disabled (`USE_KNOWLEDGE_GRAPH` not set)【F:src/crawl4ai_mcp.py†L1310-L1318】
-- Neo4j connection not available【F:src/crawl4ai_mcp.py†L1319-L1329】
-- Empty command or unknown command【F:src/crawl4ai_mcp.py†L1331-L1389】
-- Missing arguments for a command (e.g., no repository specified)【F:src/crawl4ai_mcp.py†L1347-L1388】
-- Entity not found (`class`, `method`, or `function` not present)【F:src/crawl4ai_mcp.py†L1518-L1561】【F:src/crawl4ai_mcp.py†L1677-L1692】
-- Cypher query errors are caught and returned in the response【F:src/crawl4ai_mcp.py†L1710-L1737】
+- Knowledge graph disabled (`USE_KNOWLEDGE_GRAPH` not set)
+- Neo4j connection not available
+- Empty command or unknown command
+- Missing arguments for a command (e.g., no repository specified)
+- Entity not found (`class`, `method`, or `function` not present)
+- Cypher query errors are caught and returned in the response
 
 ## Integration Examples
 
@@ -152,11 +152,11 @@ This mirrors the approach used in the tests【F:tests/test_query_function.py†L
    query MATCH (c:Class)-[:HAS_METHOD]->(m:Method) WHERE m.name="run" RETURN c.full_name
    ```
 
-These steps follow the recommended workflow from the function docstring【F:src/crawl4ai_mcp.py†L1250-L1279】.
+These steps follow the recommended workflow from the function docstring.
 
 ## Advanced Usage
 
-- You can send any Cypher query via the `query` command. Results are limited to 20 records to prevent overwhelming responses【F:src/crawl4ai_mcp.py†L1707-L1725】.
+- You can send any Cypher query via the `query` command. Results are limited to 20 records to prevent overwhelming responses.
 - Combine filters to create complex exploration patterns, e.g., find all methods with a given return type or cross-reference repositories.
 
 ## Performance Considerations

--- a/src/crawl4ai_mcp/server.py
+++ b/src/crawl4ai_mcp/server.py
@@ -49,8 +49,6 @@ from utils import (
 # Import knowledge graph modules
 from knowledge_graph_validator import KnowledgeGraphValidator
 from parse_repo_into_neo4j import DirectNeo4jExtractor
-from ai_script_analyzer import AIScriptAnalyzer
-from hallucination_reporter import HallucinationReporter
 
 # Load environment variables from the project root .env file
 project_root = Path(__file__).resolve().parent.parent

--- a/src/crawl4ai_mcp/tools.py
+++ b/src/crawl4ai_mcp/tools.py
@@ -1273,15 +1273,3 @@ async def crawl_recursive_internal_links(crawler: AsyncWebCrawler, start_urls: L
         current_urls = next_level_urls
 
     return results_all
-
-async def main():
-    transport = os.getenv("TRANSPORT", "sse")
-    if transport == 'sse':
-        # Run the MCP server with sse transport
-        await mcp.run_sse_async()
-    else:
-        # Run the MCP server with stdio transport
-        await mcp.run_stdio_async()
-
-if __name__ == "__main__":
-    asyncio.run(main())


### PR DESCRIPTION
## Summary
- drop unused hallucination analyzer imports
- remove redundant main() from tools
- update Dockerfile entrypoint
- fix README docs for new module layout
- update knowledge graph tool documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6870e3b8c7e48333ac77e377155c6000